### PR TITLE
Add lib folder to the list of published files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "src",
+    "lib",
     "ios",
     "cpp",
     "*.podspec",


### PR DESCRIPTION
Hey, awesome work on the module, thank you!

This small PR addresses #1.

Currently published npm package doesn't include the `lib/` folder, as you can see here https://www.npmjs.com/package/@wilmxre/react-native-mesh-gradient?activeTab=code, which makes the package unusable after installation.

This is caused by `lib/` folder missing from the list of files in package.json. I'm not sure at which point it dissapeared, since the template should've initially had it (see https://github.com/callstack/react-native-builder-bob/blob/main/packages/create-react-native-library/templates/common/%24package.json#L22).